### PR TITLE
Feature/retain factor levels [WIP]

### DIFF
--- a/R/flat-model-matrix.R
+++ b/R/flat-model-matrix.R
@@ -125,7 +125,7 @@ fmm_factory = methods::setRefClass(Class = "fmm",
       .self$.n_terms = length(.self$.term_width)
       .self$.term_stop = array(cumsum(.self$.term_width))
       .self$.term_start = array(c(1, .self$.term_stop[-.self$.n_terms] + 1))
-      .self$.term_names = sapply(.self$.specifiers$term_list[['rhs']], deparse)
+      .self$.term_names = sapply(.self$.specifiers$term_list[['rhs']], deparse, width.cutoff = 200L)
       .self$.term_names = gsub('^term\\(', '', .self$.term_names)
       .self$.term_names = gsub('\\)$', '', .self$.term_names)
 

--- a/R/formula.R
+++ b/R/formula.R
@@ -288,7 +288,9 @@ default_imbue_methods = function() list(
       names(x) = dots
       for (i in seq_along(x)) {
 	if (!is.list(x[[i]]) && is.null(attr(x[[i]], 'type'))) {
+	  if (!is.factor(x[[i]])) {
           x[[i]] = as.character(x[[i]])
+	  }
           attr(x[[i]], 'type') = 'intercept'
           attr(x[[i]], 'effect_type') = 'fixed'
 	} 
@@ -317,7 +319,9 @@ default_imbue_methods = function() list(
       x = list(...)
       for (i in seq_along(x)) {
         if (!is.list(x[[i]]) && is.null(attr(x[[i]], 'type'))) {
-          x[[i]] = as.character(x[[i]])
+          if (!is.factor(x[[i]])) {
+            x[[i]] = as.character(x[[i]])
+          }
           attr(x[[i]], 'type') = 'contrast'
           attr(x[[i]], 'effect_type') = 'fixed'
 	      } 
@@ -349,8 +353,10 @@ default_imbue_methods = function() list(
       names(x) = dots
       for (i in seq_along(x)) {
 	if (!is.list(x[[i]]) && is.null(attr(x[[i]], 'type'))) {
-          x[[i]] = as.character(x[[i]])
-          attr(x[[i]], 'type') = 'intercept'
+	  if (!is.factor(x[[i]])) {
+	    x[[i]] = as.character(x[[i]])
+	  }
+	        attr(x[[i]], 'type') = 'intercept'
           attr(x[[i]], 'effect_type') = 'random'
 	} 
         ith_type = attr(x[[i]], 'type')
@@ -368,8 +374,10 @@ default_imbue_methods = function() list(
         else
 	  attr(x[[i]], 'effect_type') = 'random'
         ith_at = attributes(x[[i]])
-	x[[i]] = as.character(x[[i]])
-	attributes(x[[i]]) = ith_at
+        if (!is.factor(x[[i]])) {
+          x[[i]] = as.character(x[[i]])
+        }
+        attributes(x[[i]]) = ith_at
         x[[names(x)[i]]] = list(x[[i]])
       }
     }
@@ -385,7 +393,9 @@ default_imbue_methods = function() list(
       names(x) = dots
       for (i in seq_along(x)) {
         if (!is.list(x[[i]]) && is.null(attr(x[[i]], 'type'))) {
-          x[[i]] = as.character(x[[i]])
+          if (!is.factor(x[[i]])) {
+            x[[i]] = as.character(x[[i]])
+          }
           attr(x[[i]], 'type') = 'contrast'
           attr(x[[i]], 'effect_type') = 'random'
         } 


### PR DESCRIPTION
Remove various lines casting inputs to characters, to enable prediction on either per-patient or per-patient-subset for a model fit. This is because the code now honors existing factor levels when preparing model matrices, even if not all factor levels are used.

Although this capability isn't explicitly tested here, it is verified during any prediction tasks. 

The remaining TODO is to add a test cases for this scenario.